### PR TITLE
Fix bot UI messaging and add API diagnostics

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,15 +1,25 @@
 export default async function handler(req, res) {
+  console.log('API Key verfügbar:', !!process.env.OPENAI_API_KEY);
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { message } = req.body;
+  const { message } = req.body || {};
+  console.log('Nachricht erhalten:', message);
 
   if (!message || message.length > 500) {
     return res.status(400).json({ error: 'Invalid message' });
   }
 
   const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+  if (!OPENAI_API_KEY) {
+    console.error('OPENAI_API_KEY not found in environment variables');
+    return res.status(500).json({
+      error: 'Na servas, da fehlt was in der Konfiguration! 🤖'
+    });
+  }
 
   const workshopData = {
     days: {

--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
 </head>
 <body>
   <div class="chat-container" role="main">
-    <header class="chat-header">🇦🇹 Wien Workshop Info</header>
+    <header class="chat-header">👑 Kaiser Franz - Wien Workshop</header>
     <section class="chat-messages" id="messages" aria-live="polite">
-      <div class="message bot-message">Hi! Frag mich was über den Workshop (Zeit, Ort, Essen, etc.)</div>
+      <div class="message bot-message">Gestatten, Franz hier! Fragen Sie mich allergnädigst über den Workshop (Zeit, Ort, Speisen, etc.) 👑</div>
     </section>
     <div class="chat-input">
       <form onsubmit="event.preventDefault(); sendMessage();">


### PR DESCRIPTION
## Summary
- update the chat UI header and welcome message to highlight Franz's persona
- add logging to the chat API for API key availability and incoming messages
- return a clearer error when the OpenAI API key is missing before calling the upstream API

## Testing
- Manual testing: opened the site locally to verify the updated welcome text


------
https://chatgpt.com/codex/tasks/task_e_68d6b3a41c2883239cc7ae3893d19fb7