### PR TITLE
Ensure Franz shares real Maps URLs and render clickable links

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -217,9 +217,35 @@ ANTWORT-STIL:
 - Variiere Begrüßungen - NIEMALS immer das gleiche!
 - Kurz aber charmant (max 3-4 Sätze)
 - Verwende 👑, 🇦🇹, ☕, 🍻 Emojis sparsam
-- Bei Adressen: "Hier der Weg, Euer Gnaden: [Maps-Link]"
 - Bei Problemen: "Na servas, des tut ma leid..."
 - Sei spontan und lustig, nicht steif!
+
+LINK-HANDLING:
+- Verwende IMMER die echten Maps-URLs aus den Workshop-Daten
+- Format: "Hier der Weg: [ECHTE_URL]"
+- NIEMALS "[Maps-Link]" als Platzhalter verwenden
+- Links sollen direkt klickbar sein
+
+VERFÜGBARE MAPS-URLS (verwende diese direkt):
+- OpenResearch Office: https://maps.google.com/?q=Biberstraße%209,%201010%20Wien
+- Viva la Mamma: https://maps.google.com/?q=Dr.-Karl-Lueger-Platz%205,%201010%20Wien
+- Figlmüller: https://maps.google.com/?q=Bäckerstraße%206,%201010%20Wien
+- Topgolf: https://maps.google.com/?q=Wiener%20Straße%20196,%202345%20Brunn%20am%20Gebirge
+- Das Schinakl: https://maps.google.com/?q=Laberlweg%2019,%201220%20Wien
+- Meissl & Schadn: https://maps.google.com/?q=Schubertring%2010–12,%201010%20Wien
+- Parken Ernst-Sadil-Platz: https://maps.google.com/?q=Ernst-Sadil-Platz%201-2,%201220%20Wien
+- Parken Schödlbergergasse: https://maps.google.com/?q=Schödlbergergasse%207,%201220%20Wien
+- Zusätzliche Parklinks: https://maps.app.goo.gl/MyPMa2KKWsMm5vSR6 und https://maps.app.goo.gl/1LZDzNmUzvxfMu3t5
+
+LINK-BEISPIELE:
+Frage: "wo ist viva la mamma?"
+Antwort: "Na servas! Die Viva la Mamma ist am Dr.-Karl-Lueger-Platz 5. Hier der Weg, Euer Gnaden: https://maps.google.com/?q=Dr.-Karl-Lueger-Platz%205,%201010%20Wien 🍝"
+
+Frage: "workshop adresse?"
+Antwort: "Des OpenResearch Office ist in der Biberstraße 9! Hier geht's hin: https://maps.google.com/?q=Biberstraße%209,%201010%20Wien 👑"
+
+Frage: "wo parken für insel?"
+Antwort: "Für die Insel empfehl ich Ernst-Sadil-Platz: https://maps.google.com/?q=Ernst-Sadil-Platz%201-2,%201220%20Wien oder Schödlbergergasse: https://maps.google.com/?q=Schödlbergergasse%207,%201220%20Wien 🚗"
 
 CONVERSATIONAL RULES:
 - Reagiere auf den Kontext (erste Nachricht vs. Folgenachricht)

--- a/script.js
+++ b/script.js
@@ -28,7 +28,13 @@ function formatBotMessage(message) {
   const safeMessage = typeof message === 'string' ? message : String(message ?? '');
   const temp = document.createElement('div');
   temp.textContent = safeMessage;
-  return temp.innerHTML.replace(/\n/g, '<br>');
+  let html = temp.innerHTML.replace(/\n/g, '<br>');
+
+  // URLs zu klickbaren Links machen
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  html = html.replace(urlRegex, '<a href="$1" target="_blank" rel="noopener">$1</a>');
+
+  return html;
 }
 
 async function getOpenAIResponse(userMessage) {

--- a/style.css
+++ b/style.css
@@ -102,10 +102,23 @@ body {
 }
 
 .message a {
-  color: inherit;
+  color: #0066cc;
   font-weight: 600;
   text-decoration: underline;
   word-break: break-all;
+  transition: color 0.2s ease;
+}
+
+.message a:hover {
+  color: #004499;
+}
+
+.bot-message a {
+  color: #d62828;
+}
+
+.bot-message a:hover {
+  color: #b01e1e;
 }
 
 .chat-input {


### PR DESCRIPTION
## Summary
- expand the system prompt with explicit maps link handling instructions and available workshop URLs
- convert bot responses' URLs into clickable links and adjust styling for regular and bot messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b9f6badc8323b0ee48e6c5ae3019