### PR TITLE
feat: refresh chat interface with black and pink palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,7 @@
 </head>
 <body>
   <div class="chat-container" role="main">
-    <header class="chat-header">
-      <div class="chat-header-text">
-        👑 Kaiser Franz • Wien Workshop • OpenResearch 🇦🇹
-      </div>
-    </header>
+    <header class="chat-header">🇦🇹 Wien Workshop Info</header>
     <section class="chat-messages" id="messages" aria-live="polite">
       <div class="message bot-message">Gestatten, Franz hier! Fragen Sie mich allergnädigst über den Workshop (Zeit, Ort, Speisen, etc.) 👑</div>
     </section>

--- a/style.css
+++ b/style.css
@@ -1,119 +1,99 @@
 :root {
-  /* Österreich Flagge Farben */
-  --austria-red: #C8102E;
-  --austria-white: #FFFFFF;
-
-  /* OpenResearch Branding */
-  --openresearch-black: #000000;
-  --openresearch-pink: #FF1493;
-
+  /* OpenResearch Clean Palette */
+  --or-black: #000000;
+  --or-pink: #FF1493;
+  --white: #ffffff;
+  --light-gray: #f8f9fa;
+  --border-gray: #e1e5e9;
+  
   /* Chat Design */
-  --bg-gradient: linear-gradient(135deg, #C8102E 0%, #FF1493 50%, #000000 100%);
-  --chat-bg: rgba(255, 255, 255, 0.95);
-  --user-bubble: linear-gradient(135deg, #C8102E, #FF1493);
-  --bot-bubble: #FFFFFF;
-  --accent-gold: #FFD700;
-
-  /* Shadows & Effects */
-  --shadow-austria: 0 8px 32px rgba(200, 16, 46, 0.2);
-  --shadow-openresearch: 0 4px 20px rgba(255, 20, 147, 0.3);
+  --bg: var(--light-gray);
+  --user-bubble: var(--or-pink);
+  --bot-bubble: var(--white);
+  --text-dark: var(--or-black);
+  --text-light: var(--white);
 }
 
 * {
   box-sizing: border-box;
 }
 
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 body {
   margin: 0;
-  padding: 0;
   font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  background: var(--bg-gradient);
+  background: var(--bg);
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--openresearch-black);
   padding: 8px;
-  box-sizing: border-box;
+  color: var(--text-dark);
 }
 
 .chat-container {
   width: 100%;
   max-width: 100%;
   height: calc(100vh - 16px);
-  background: var(--chat-bg);
-  backdrop-filter: blur(12px);
-  border-radius: 16px;
-  box-shadow: var(--shadow-austria);
+  background: var(--white);
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 2px solid var(--austria-red);
-  position: relative;
+  border: 1px solid var(--border-gray);
+}
+
+@media (min-width: 768px) {
+  .chat-container {
+    max-width: 420px;
+    height: 600px;
+    border-radius: 16px;
+  }
 }
 
 .chat-header {
-  background: linear-gradient(135deg, var(--austria-red) 0%, var(--openresearch-pink) 100%);
-  color: var(--austria-white);
+  background: var(--or-black);
+  color: var(--white);
   padding: 16px 20px;
   font-size: 1.1rem;
-  font-weight: 700;
+  font-weight: 600;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
-  position: relative;
-  overflow: hidden;
+  flex-shrink: 0;
 }
 
-.chat-header::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: repeating-linear-gradient(
-    90deg,
-    transparent,
-    transparent 10px,
-    rgba(255, 255, 255, 0.1) 10px,
-    rgba(255, 255, 255, 0.1) 11px
-  );
-}
-
-.chat-header-text {
-  position: relative;
-  z-index: 1;
+@media (max-width: 767px) {
+  .chat-header {
+    padding: 14px 16px;
+    font-size: 1rem;
+  }
 }
 
 .chat-messages {
   flex: 1;
-  padding: 16px 12px 12px;
+  padding: 16px 12px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.98) 0%,
-    rgba(248, 249, 250, 0.95) 100%
-  );
+  background: var(--bg);
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
+}
+
+.chat-messages::-webkit-scrollbar {
+  width: 3px;
+}
+
+.chat-messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-messages::-webkit-scrollbar-thumb {
+  background: var(--or-pink);
+  border-radius: 2px;
 }
 
 .message {
@@ -124,67 +104,54 @@ body {
   font-size: 0.95rem;
   word-break: break-word;
   animation: slideIn 0.3s ease;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-  min-height: 44px;
-  display: flex;
-  align-items: center;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .bot-message {
   align-self: flex-start;
   background: var(--bot-bubble);
-  border: 1px solid rgba(200, 16, 46, 0.2);
+  border: 1px solid var(--border-gray);
   border-bottom-left-radius: 6px;
-  box-shadow: var(--shadow-openresearch);
+  color: var(--text-dark);
 }
 
 .user-message {
   align-self: flex-end;
   background: var(--user-bubble);
-  color: var(--austria-white);
+  color: var(--text-light);
   border-bottom-right-radius: 6px;
-  box-shadow: var(--shadow-austria);
 }
 
 .message a {
-  color: var(--austria-red);
+  color: var(--or-pink);
   font-weight: 600;
   text-decoration: underline;
   word-break: break-all;
-  transition: all 0.2s ease;
+  transition: opacity 0.2s ease;
 }
 
 .message a:hover {
-  color: var(--openresearch-pink);
-  text-shadow: 0 1px 2px rgba(255, 20, 147, 0.3);
-}
-
-.bot-message a {
-  color: var(--austria-red);
+  opacity: 0.8;
 }
 
 .user-message a {
-  color: var(--austria-white);
+  color: var(--white);
   text-decoration-color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 767px) {
+  .message {
+    max-width: 88%;
+    padding: 10px 14px;
+    font-size: 0.9rem;
+  }
 }
 
 .chat-input {
   padding: 12px;
-  background: rgba(255, 255, 255, 0.98);
-  border-top: 2px solid var(--austria-red);
+  background: var(--white);
+  border-top: 1px solid var(--border-gray);
   flex-shrink: 0;
-}
-
-.quick-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 12px;
-  background: linear-gradient(90deg, var(--austria-red) 0%, var(--austria-white) 50%, var(--austria-red) 100%);
-  border-top: 1px solid rgba(200, 16, 46, 0.3);
-  flex-shrink: 0;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .chat-input form {
@@ -195,66 +162,69 @@ body {
 
 .chat-input input {
   flex: 1;
-  padding: 14px 18px;
-  border-radius: 25px;
-  border: 2px solid var(--austria-red);
+  padding: 12px 16px;
+  border-radius: 24px;
+  border: 1px solid var(--border-gray);
   font-size: 1rem;
   outline: none;
-  transition: all 0.3s ease;
-  background: var(--austria-white);
-  -webkit-appearance: none;
-  appearance: none;
+  transition: border-color 0.2s ease;
+  background: var(--light-gray);
 }
 
 .chat-input input:focus {
-  border-color: var(--openresearch-pink);
-  box-shadow: 0 0 0 3px rgba(255, 20, 147, 0.2);
-  transform: translateY(-1px);
+  border-color: var(--or-pink);
+  background: var(--white);
 }
 
 .chat-input button {
-  background: linear-gradient(135deg, var(--austria-red), var(--openresearch-pink));
-  color: var(--austria-white);
+  background: var(--or-pink);
+  color: var(--white);
   border: none;
   border-radius: 50%;
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
   font-size: 1.2rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.3s ease;
-  box-shadow: var(--shadow-austria);
-  min-width: 48px;
-  min-height: 48px;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
 }
 
-.chat-input button:hover,
-.chat-input button:focus {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(200, 16, 46, 0.4);
+.chat-input button:hover {
+  transform: scale(1.05);
+}
+
+.chat-input button:active {
+  transform: scale(0.95);
+}
+
+@media (max-width: 767px) {
+  .chat-input {
+    padding: 10px;
+  }
+  
+  .chat-input input {
+    font-size: 16px;
+    padding: 10px 14px;
+  }
+  
+  .chat-input button {
+    width: 40px;
+    height: 40px;
+    font-size: 1.1rem;
+  }
 }
 
 .loading-dots {
   display: inline-block;
-  color: var(--austria-red);
+  color: var(--or-pink);
 }
 
 .loading-dots::after {
   content: '...';
   animation: dots 1.5s infinite;
-}
-
-@keyframes slideIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 @keyframes dots {
@@ -269,99 +239,25 @@ body {
   }
 }
 
-.quick-btn {
-  background: linear-gradient(135deg, var(--openresearch-black), var(--openresearch-pink));
-  color: var(--austria-white);
-  border: none;
-  padding: 10px 16px;
-  border-radius: 20px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  cursor: pointer;
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
   white-space: nowrap;
-  transition: all 0.3s ease;
-  min-height: 40px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.quick-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-openresearch);
-}
-
-.quick-btn:active {
-  transform: scale(0.98);
-}
-
-@media (max-height: 600px) {
-  .chat-container {
-    height: 95vh;
-    max-height: none;
-  }
-}
-
-@media (min-width: 768px) {
-  body {
-    padding: 20px;
-  }
-
-  .chat-container {
-    max-width: 420px;
-    height: 85vh;
-    border-radius: 24px;
-  }
-}
-
-@media (max-width: 767px) {
-  .chat-header {
-    padding: 14px 16px;
-    font-size: 1rem;
-  }
-
-  .message {
-    max-width: 88%;
-    padding: 10px 14px;
-    font-size: 0.9rem;
-  }
-
-  .chat-input {
-    padding: 10px;
-  }
-
-  .chat-input input {
-    padding: 12px 16px;
-    font-size: 16px;
-  }
-
-  .chat-input button {
-    width: 44px;
-    height: 44px;
-    min-width: 44px;
-    min-height: 44px;
-  }
-
-  .quick-buttons {
-    padding: 8px 10px;
-  }
-
-  .quick-btn {
-    padding: 8px 14px;
-    font-size: 0.8rem;
-    min-height: 36px;
-  }
-}
-
-.chat-messages::-webkit-scrollbar {
-  width: 4px;
-}
-
-.chat-messages::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.chat-messages::-webkit-scrollbar-thumb {
-  background: var(--austria-red);
-  border-radius: 2px;
+  border: 0;
 }


### PR DESCRIPTION
## Summary
- restyle the chat interface with a minimal black and pink palette and updated typography
- simplify the layout for mobile-first usage with refined message bubbles and input controls
- refresh the header branding to highlight the Vienna workshop information

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6c1cc283883238a42b697bfc1ec7a