### PR TITLE
Implement workshop token redemption flow

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,3 +1,5 @@
+import { franzExtensions } from './tokens.js';
+
 export default async function handler(req, res) {
   console.log('=== API CALL START ===');
   console.log('Method:', req.method);
@@ -364,7 +366,7 @@ export default async function handler(req, res) {
     }
   };
 
-  const systemPrompt = `Du bist Franz, ein charmanter Wiener Herr im Stil von Kaiser Franz Joseph I. Du hilfst bei einem Workshop in Wien vom 29.09-01.10.2025.
+  let systemPrompt = `Du bist Franz, ein charmanter Wiener Herr im Stil von Kaiser Franz Joseph I. Du hilfst bei einem Workshop in Wien vom 29.09-01.10.2025.
 
 PERSÖNLICHKEIT:
 - Höflich und altmodisch, aber herzlich und lustig
@@ -458,6 +460,27 @@ Frage: "danke"
 Antwort: "Des freut mich aber! Immer gern, wertes Herrschaftl! 🇦🇹"
 
 WICHTIG: Jede Antwort soll anders beginnen! Sei kreativ mit den Wiener Ausdrücken!`;
+
+  if (franzExtensions.facts.length > 0) {
+    systemPrompt += `\nVON WORKSHOP-GEWINNERN HINZUGEFÜGTE FAKTEN:\n`;
+    franzExtensions.facts.forEach(fact => {
+      systemPrompt += `- ${fact.content} (von ${fact.winner})\n`;
+    });
+  }
+
+  if (franzExtensions.phrases.length > 0) {
+    systemPrompt += `\nNEUE WIENER PHRASEN VON GEWINNERN:\n`;
+    franzExtensions.phrases.forEach(phrase => {
+      systemPrompt += `- ${phrase.content} (von ${phrase.winner})\n`;
+    });
+  }
+
+  if (franzExtensions.behaviors.length > 0) {
+    systemPrompt += `\nNEUE VERHALTENSWEISEN VON GEWINNERN:\n`;
+    franzExtensions.behaviors.forEach(behavior => {
+      systemPrompt += `- ${behavior.content} (von ${behavior.winner})\n`;
+    });
+  }
 
   try {
     console.log('🔄 Calling OpenAI with full conversation...');

--- a/api/tokens.js
+++ b/api/tokens.js
@@ -1,0 +1,123 @@
+// In-Memory Token Store (reset bei Deployment)
+let tokenStore = {
+  'win1-abc123': { used: false, winner: null, type: 'fact' },
+  'win2-def456': { used: false, winner: null, type: 'phrase' },
+  'win3-ghi789': { used: false, winner: null, type: 'behavior' },
+  'win4-jkl012': { used: false, winner: null, type: 'fact' },
+  'win5-mno345': { used: false, winner: null, type: 'phrase' },
+  // ... mehr Tokens nach Bedarf
+};
+
+let franzExtensions = {
+  facts: [],
+  phrases: [],
+  behaviors: []
+};
+
+export default async function handler(req, res) {
+  if (req.method === 'GET') {
+    // Token-Status prüfen
+    const { token } = req.query;
+
+    if (!token || !tokenStore[token]) {
+      return res.status(404).json({ error: 'Token nicht gefunden' });
+    }
+
+    if (tokenStore[token].used) {
+      return res.status(410).json({ error: 'Token bereits verwendet' });
+    }
+
+    return res.status(200).json({
+      valid: true,
+      type: tokenStore[token].type,
+      message: 'Token ist gültig!'
+    });
+  }
+
+  if (req.method === 'POST') {
+    // Token einlösen
+    const { token, content, winner_name } = req.body;
+
+    if (!token || !content || !winner_name) {
+      return res.status(400).json({ error: 'Token, Content und Name erforderlich' });
+    }
+
+    if (!tokenStore[token]) {
+      return res.status(404).json({ error: 'Token nicht gefunden' });
+    }
+
+    if (tokenStore[token].used) {
+      return res.status(410).json({ error: 'Token bereits verwendet' });
+    }
+
+    // Content validieren
+    if (content.length > 150) {
+      return res.status(400).json({ error: 'Text zu lang (max 150 Zeichen)' });
+    }
+
+    if (winner_name.length > 30) {
+      return res.status(400).json({ error: 'Name zu lang (max 30 Zeichen)' });
+    }
+
+    // Verbotene Wörter (optional)
+    const badWords = ['hack', 'delete', 'admin', 'password'];
+    if (badWords.some(word => content.toLowerCase().includes(word))) {
+      return res.status(400).json({ error: 'Unerlaubter Inhalt' });
+    }
+
+    const type = tokenStore[token].type;
+
+    if (!['fact', 'phrase', 'behavior'].includes(type)) {
+      return res.status(400).json({ error: 'Ungültiger Tokentyp' });
+    }
+
+    if (!franzExtensions[type]) {
+      franzExtensions[type] = [];
+    }
+
+    const timestamp = new Date().toISOString();
+
+    // Token als verwendet markieren
+    tokenStore[token].used = true;
+    tokenStore[token].winner = winner_name;
+    tokenStore[token].content = content;
+    tokenStore[token].timestamp = timestamp;
+
+    // Zu Franz hinzufügen
+    const entry = {
+      content,
+      winner: winner_name,
+      timestamp,
+      token
+    };
+
+    franzExtensions[type].push(entry);
+
+    return res.status(200).json({
+      success: true,
+      message: `Franz wurde erfolgreich um ${type} erweitert!`,
+      winner: winner_name
+    });
+  }
+
+  // Admin endpoint für Token-Status
+  if (req.method === 'DELETE') {
+    const { admin_key } = req.body || {};
+    if (admin_key === 'workshop2025admin') {
+      // Token-Status für Admin
+      const status = Object.entries(tokenStore).map(([token, data]) => ({
+        token: `${token.substring(0, 8)}...`,
+        used: data.used,
+        winner: data.winner,
+        type: data.type
+      }));
+      return res.status(200).json({ tokens: status });
+    }
+
+    return res.status(403).json({ error: 'Admin Key ungültig' });
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}
+
+export { franzExtensions, tokenStore };

--- a/generate-tokens.js
+++ b/generate-tokens.js
@@ -1,0 +1,18 @@
+function generateTokens(count = 10) {
+  const tokens = {};
+  const types = ['fact', 'phrase', 'behavior'];
+
+  for (let i = 1; i <= count; i++) {
+    const id = 'win' + i + '-' + Math.random().toString(36).substr(2, 6);
+    tokens[id] = {
+      used: false,
+      winner: null,
+      type: types[Math.floor(Math.random() * types.length)]
+    };
+  }
+
+  console.log('Kopiere das in /api/tokens.js:');
+  console.log(JSON.stringify(tokens, null, 2));
+}
+
+generateTokens(15);

--- a/token.html
+++ b/token.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Workshop Gewinner Token</title>
+    <style>
+        body {
+            font-family: system-ui, sans-serif;
+            background: #f8f9fa;
+            margin: 0;
+            padding: 20px;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .token-container {
+            background: white;
+            max-width: 400px;
+            width: 100%;
+            padding: 30px;
+            border-radius: 16px;
+            box-shadow: 0 8px 30px rgba(0,0,0,0.1);
+            text-align: center;
+        }
+        h1 {
+            color: #000;
+            margin-bottom: 10px;
+        }
+        .subtitle {
+            color: #FF1493;
+            margin-bottom: 30px;
+            font-size: 0.9rem;
+        }
+        .form-group {
+            margin-bottom: 20px;
+            text-align: left;
+        }
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 8px;
+            color: #333;
+        }
+        input, textarea {
+            width: 100%;
+            padding: 12px;
+            border: 2px solid #e1e5e9;
+            border-radius: 8px;
+            font-size: 16px;
+            box-sizing: border-box;
+            transition: border-color 0.2s;
+        }
+        input:focus, textarea:focus {
+            outline: none;
+            border-color: #FF1493;
+        }
+        textarea {
+            height: 80px;
+            resize: vertical;
+        }
+        .submit-btn {
+            background: #FF1493;
+            color: white;
+            border: none;
+            padding: 14px 28px;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            width: 100%;
+            transition: background-color 0.2s;
+        }
+        .submit-btn:hover {
+            background: #e1127f;
+        }
+        .submit-btn:disabled {
+            background: #ccc;
+            cursor: not-allowed;
+        }
+        .status {
+            margin-top: 20px;
+            padding: 12px;
+            border-radius: 8px;
+            display: none;
+        }
+        .success {
+            background: #d4edda;
+            color: #155724;
+            border: 2px solid #c3e6cb;
+        }
+        .error {
+            background: #f8d7da;
+            color: #721c24;
+            border: 2px solid #f5c6cb;
+        }
+        .loading {
+            background: #d1ecf1;
+            color: #0c5460;
+            border: 2px solid #bee5eb;
+        }
+        .char-count {
+            font-size: 0.8rem;
+            color: #666;
+            text-align: right;
+            margin-top: 4px;
+        }
+    </style>
+</head>
+<body>
+    <div class="token-container">
+        <h1>🎉 Workshop Gewinner!</h1>
+        <div class="subtitle">Du kannst Franz beibringen, etwas Neues zu wissen!</div>
+        
+        <div id="loading" class="status loading" style="display: block;">
+            Token wird überprüft...
+        </div>
+        
+        <form id="tokenForm" style="display: none;">
+            <div class="form-group">
+                <label for="winner_name">Dein Name:</label>
+                <input type="text" id="winner_name" maxlength="30" placeholder="z.B. Max Mustermann" required>
+            </div>
+            
+            <div class="form-group">
+                <label for="content">Was soll Franz lernen?</label>
+                <textarea id="content" maxlength="150" placeholder="z.B. 'Franz weiß dass Max der beste Topgolf-Spieler ist'" required></textarea>
+                <div class="char-count">
+                    <span id="charCount">0</span>/150 Zeichen
+                </div>
+            </div>
+            
+            <button type="submit" class="submit-btn">Franz Updaten! 🚀</button>
+        </form>
+        
+        <div id="status" class="status"></div>
+    </div>
+    
+    <script>
+        const loadingElement = document.getElementById('loading');
+
+        // Token aus URL extrahieren
+        const urlParams = new URLSearchParams(window.location.search);
+        const token = urlParams.get('token');
+        
+        if (!token) {
+            loadingElement.style.display = 'none';
+            showError('Kein Token in URL gefunden');
+        } else {
+            checkToken();
+        }
+        
+        async function checkToken() {
+            try {
+                const response = await fetch(`/api/tokens?token=${encodeURIComponent(token)}`);
+                const data = await response.json();
+                
+                loadingElement.style.display = 'none';
+                
+                if (response.ok) {
+                    document.getElementById('tokenForm').style.display = 'block';
+                    
+                    // Platzhalter je nach Type
+                    const contentField = document.getElementById('content');
+                    if (data.type === 'fact') {
+                        contentField.placeholder = 'z.B. "Franz weiß dass Max der beste Topgolf-Spieler ist"';
+                    } else if (data.type === 'phrase') {
+                        contentField.placeholder = 'z.B. "Franz sagt manchmal \'Leiwand oida!\'"';
+                    } else if (data.type === 'behavior') {
+                        contentField.placeholder = 'z.B. "Franz gratuliert dem Gewinner-Team bei jeder Antwort"';
+                    }
+                } else {
+                    showError(data.error);
+                }
+            } catch (error) {
+                loadingElement.style.display = 'none';
+                showError('Fehler beim Token-Check');
+            }
+        }
+        
+        // Character Counter
+        document.getElementById('content').addEventListener('input', (e) => {
+            document.getElementById('charCount').textContent = e.target.value.length;
+        });
+        
+        // Form Submit
+        document.getElementById('tokenForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            
+            const winner_name = document.getElementById('winner_name').value;
+            const content = document.getElementById('content').value;
+            
+            if (!winner_name || !content) return;
+            
+            const submitBtn = document.querySelector('.submit-btn');
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Wird gespeichert...';
+            
+            try {
+                const response = await fetch('/api/tokens', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        token,
+                        content,
+                        winner_name
+                    })
+                });
+                
+                const result = await response.json();
+                
+                if (response.ok) {
+                    showSuccess(`🎉 Super! Franz hat "${content}" gelernt. Probiert es aus!`);
+                    document.getElementById('tokenForm').style.display = 'none';
+                } else {
+                    showError(result.error);
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = 'Franz Updaten! 🚀';
+                }
+                
+            } catch (error) {
+                showError('Fehler beim Speichern');
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Franz Updaten! 🚀';
+            }
+        });
+        
+        function showError(message) {
+            const status = document.getElementById('status');
+            status.className = 'status error';
+            status.textContent = '❌ ' + message;
+            status.style.display = 'block';
+        }
+        
+        function showSuccess(message) {
+            const status = document.getElementById('status');
+            status.className = 'status success';
+            status.textContent = message;
+            status.style.display = 'block';
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an in-memory token management API with validation, redemption, and admin status reporting
- expose workshop winner token redemption page and feed their content into the chat system prompt
- add a helper script to generate token seeds for workshops

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6c5d5e9488323ad445ab57678522c