### PR TITLE
Add Franz extension debugging and persist token updates

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -3,6 +3,12 @@ import { franzExtensions } from './tokens.js';
 export default async function handler(req, res) {
   console.log('=== API CALL START ===');
   console.log('Method:', req.method);
+  console.log('Franz Extensions Status:', {
+    facts: franzExtensions.facts.length,
+    phrases: franzExtensions.phrases.length,
+    behaviors: franzExtensions.behaviors.length,
+    allExtensions: franzExtensions
+  });
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -604,6 +610,10 @@ Antwort: "Heute ist ${today}. ${workshopDay ? `Das ist unser Workshop-${workshop
       systemPrompt += `- ${behavior.content} (von ${behavior.winner})\n`;
     });
   }
+
+  console.log('=== SYSTEM PROMPT ===');
+  console.log(systemPrompt);
+  console.log('=== END SYSTEM PROMPT ===');
 
   try {
     console.log('🔄 Calling OpenAI with full conversation...');

--- a/api/tokens.js
+++ b/api/tokens.js
@@ -115,8 +115,10 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: 'Ungültiger Tokentyp' });
     }
 
-    if (!franzExtensions[type]) {
-      franzExtensions[type] = [];
+    const typeKey = `${type}s`;
+
+    if (!franzExtensions[typeKey]) {
+      franzExtensions[typeKey] = [];
     }
 
     const timestamp = new Date().toISOString();
@@ -135,12 +137,15 @@ export default async function handler(req, res) {
       token
     };
 
-    franzExtensions[type].push(entry);
+    franzExtensions[typeKey].push(entry);
+
+    console.log('Franz Extensions after adding:', franzExtensions);
 
     return res.status(200).json({
       success: true,
       message: `Franz wurde erfolgreich um ${type} erweitert!`,
-      winner: winner_name
+      winner: winner_name,
+      debug: franzExtensions
     });
   }
 


### PR DESCRIPTION
## Summary
- log Franz extension state and full system prompt when handling chat requests
- ensure token redemptions append to the correct Franz extension arrays and include debug output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d371bd888323a28eab1b105344e6