### PR TITLE
Add persistent storage for Franz extensions

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,8 +1,35 @@
-import { franzExtensions } from './tokens.js';
+import fs from 'fs';
+
+const STORAGE_FILE = '/tmp/franz-extensions.json';
+
+function loadExtensions() {
+  try {
+    if (fs.existsSync(STORAGE_FILE)) {
+      const data = fs.readFileSync(STORAGE_FILE, 'utf8');
+      const parsed = JSON.parse(data);
+      return {
+        facts: Array.isArray(parsed.facts) ? parsed.facts : [],
+        phrases: Array.isArray(parsed.phrases) ? parsed.phrases : [],
+        behaviors: Array.isArray(parsed.behaviors) ? parsed.behaviors : []
+      };
+    }
+  } catch (error) {
+    console.error('Error loading extensions:', error);
+  }
+
+  console.log('No extensions found, using empty state');
+  return {
+    facts: [],
+    phrases: [],
+    behaviors: []
+  };
+}
 
 export default async function handler(req, res) {
   console.log('=== API CALL START ===');
   console.log('Method:', req.method);
+
+  const franzExtensions = loadExtensions();
   console.log('Franz Extensions Status:', {
     facts: franzExtensions.facts.length,
     phrases: franzExtensions.phrases.length,


### PR DESCRIPTION
## Summary
- add file-based persistence for Franz extensions in the tokens API using `/tmp`
- reload extensions from disk on every chat request so Franz sees persisted updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d900a63083238a1c5840f0c43fcb