### PR TITLE
Add debug logging for chat extensions and create debug endpoint

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -26,16 +26,14 @@ function loadExtensions() {
 }
 
 export default async function handler(req, res) {
-  console.log('=== API CALL START ===');
+  console.log('=== CHAT API START ===');
   console.log('Method:', req.method);
 
   const franzExtensions = loadExtensions();
-  console.log('Franz Extensions Status:', {
-    facts: franzExtensions.facts.length,
-    phrases: franzExtensions.phrases.length,
-    behaviors: franzExtensions.behaviors.length,
-    allExtensions: franzExtensions
-  });
+  console.log('🔍 RAW Extensions loaded:', JSON.stringify(franzExtensions, null, 2));
+  console.log('🔍 Facts count:', franzExtensions.facts?.length || 0);
+  console.log('🔍 Phrases count:', franzExtensions.phrases?.length || 0);
+  console.log('🔍 Behaviors count:', franzExtensions.behaviors?.length || 0);
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -617,30 +615,41 @@ Frage: "was machen wir heute?"
 Frage: "welcher tag ist heute?"
 Antwort: "Heute ist ${today}. ${workshopDay ? `Das ist unser Workshop-${workshopDay}!` : 'Kein Workshop heute.'}"`;
 
+  console.log('🔍 Building systemPrompt with extensions...');
+
   if (franzExtensions.facts.length > 0) {
+    console.log('✅ Adding facts to systemPrompt:', franzExtensions.facts);
     systemPrompt += `\nVON WORKSHOP-GEWINNERN HINZUGEFÜGTE FAKTEN:\n`;
     franzExtensions.facts.forEach(fact => {
       systemPrompt += `- ${fact.content} (von ${fact.winner})\n`;
     });
+  } else {
+    console.log('❌ No facts found');
   }
 
   if (franzExtensions.phrases.length > 0) {
+    console.log('✅ Adding phrases to systemPrompt:', franzExtensions.phrases);
     systemPrompt += `\nNEUE WIENER PHRASEN VON GEWINNERN:\n`;
     franzExtensions.phrases.forEach(phrase => {
       systemPrompt += `- ${phrase.content} (von ${phrase.winner})\n`;
     });
+  } else {
+    console.log('❌ No phrases found');
   }
 
   if (franzExtensions.behaviors.length > 0) {
+    console.log('✅ Adding behaviors to systemPrompt:', franzExtensions.behaviors);
     systemPrompt += `\nNEUE VERHALTENSWEISEN VON GEWINNERN:\n`;
     franzExtensions.behaviors.forEach(behavior => {
       systemPrompt += `- ${behavior.content} (von ${behavior.winner})\n`;
     });
+  } else {
+    console.log('❌ No behaviors found');
   }
 
-  console.log('=== SYSTEM PROMPT ===');
-  console.log(systemPrompt);
-  console.log('=== END SYSTEM PROMPT ===');
+  console.log('🔍 FINAL SYSTEM PROMPT PREVIEW (last 800 chars):');
+  console.log(systemPrompt.substring(Math.max(0, systemPrompt.length - 800)));
+  console.log('🔍 SYSTEM PROMPT LENGTH:', systemPrompt.length);
 
   try {
     console.log('🔄 Calling OpenAI with full conversation...');

--- a/api/debug-extensions.js
+++ b/api/debug-extensions.js
@@ -1,0 +1,38 @@
+import fs from 'fs';
+
+const STORAGE_FILE = '/tmp/franz-extensions.json';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    let extensions = {
+      facts: [],
+      phrases: [],
+      behaviors: []
+    };
+
+    if (fs.existsSync(STORAGE_FILE)) {
+      const data = fs.readFileSync(STORAGE_FILE, 'utf8');
+      extensions = JSON.parse(data);
+    }
+
+    return res.status(200).json({
+      fileExists: fs.existsSync(STORAGE_FILE),
+      extensions: extensions,
+      totalExtensions: (extensions.facts?.length || 0) + (extensions.phrases?.length || 0) + (extensions.behaviors?.length || 0),
+      debug: {
+        storageFile: STORAGE_FILE,
+        timestamp: new Date().toISOString()
+      }
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message,
+      storageFile: STORAGE_FILE,
+      fileExists: fs.existsSync(STORAGE_FILE)
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed logging around extension loading and system prompt construction in the chat API
- provide a debug endpoint to inspect persisted Franz extensions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6db1c89888323b77a939fe282bf1b