### PR TITLE
Simplify extension token handling

### DIFF
--- a/admin-tokens.html
+++ b/admin-tokens.html
@@ -184,20 +184,7 @@
         <button class="btn btn-secondary" onclick="loadFranzExtensions()">Franz-Wissen laden</button>
         
         <div id="franzKnowledge" class="franz-knowledge" style="display: none;">
-            <div class="knowledge-section">
-                <h3>📝 Facts</h3>
-                <div id="factsList" class="extension-list">Keine Facts</div>
-            </div>
-            
-            <div class="knowledge-section">
-                <h3>💬 Phrases</h3>
-                <div id="phrasesList" class="extension-list">Keine Phrases</div>
-            </div>
-            
-            <div class="knowledge-section">
-                <h3>🎭 Behaviors</h3>
-                <div id="behaviorsList" class="extension-list">Keine Behaviors</div>
-            </div>
+            <div class="empty-state">Noch keine Daten geladen</div>
         </div>
     </div>
 
@@ -281,8 +268,7 @@
             
             tokenList.innerHTML = tokens.map(token => `
                 <div class="token-item ${token.used ? 'used' : ''}">
-                    <strong>${token.token}</strong> 
-                    [${token.type}] 
+                    <strong>${token.token}</strong>
                     ${token.used ? `✅ Verwendet von: ${token.winner}` : '⏳ Verfügbar'}
                 </div>
             `).join('');
@@ -304,47 +290,48 @@
             setTimeout(() => status.style.display = 'none', 5000);
         }
 
+        function displayFranzKnowledge(extensions) {
+            const container = document.getElementById('franzKnowledge');
+            
+            if (!extensions || extensions.length === 0) {
+                container.innerHTML = '<div class="empty-state">Franz weiß noch nichts Neues</div>';
+                return;
+            }
+            
+            container.innerHTML = `
+                <div class="knowledge-section">
+                  <h3>🧠 Franz Wissen (${extensions.length} Einträge)</h3>
+                  <div class="extension-list">
+                    ${extensions.map(ext => `
+                      <div class="extension-item">
+                        <div><strong>${ext.content}</strong></div>
+                        <div class="extension-meta">
+                          Von: ${ext.winner} | 
+                          Token: ${ext.token} | 
+                          ${new Date(ext.timestamp).toLocaleString('de-DE')}
+                        </div>
+                      </div>
+                    `).join('')}
+                  </div>
+                </div>
+            `;
+        }
+
         async function loadFranzExtensions() {
             try {
                 const response = await fetch('/api/debug-extensions');
                 const result = await response.json();
-
+                
                 if (response.ok) {
                     displayFranzKnowledge(result.extensions);
                     document.getElementById('franzKnowledge').style.display = 'block';
-                    showSuccess(`Franz kennt ${result.totalExtensions} Extensions`);
+                    showSuccess(`Franz kennt ${result.totalExtensions} neue Dinge`);
                 } else {
                     showError('Fehler beim Laden von Franz-Wissen');
                 }
             } catch (error) {
                 showError('Fehler beim Laden');
             }
-        }
-
-        function displayFranzKnowledge(extensions) {
-            displayExtensionType('factsList', extensions.facts || []);
-            displayExtensionType('phrasesList', extensions.phrases || []);
-            displayExtensionType('behaviorsList', extensions.behaviors || []);
-        }
-
-        function displayExtensionType(elementId, items) {
-            const container = document.getElementById(elementId);
-
-            if (items.length === 0) {
-                container.innerHTML = '<div class="empty-state">Keine Einträge</div>';
-                return;
-            }
-
-            container.innerHTML = items.map(item => `
-                <div class="extension-item">
-                    <div><strong>${item.content}</strong></div>
-                    <div class="extension-meta">
-                        Von: ${item.winner} |
-                        Token: ${item.token} |
-                        ${new Date(item.timestamp).toLocaleString('de-DE')}
-                    </div>
-                </div>
-            `).join('');
         }
 
         function refreshAll() {

--- a/api/debug-extensions.js
+++ b/api/debug-extensions.js
@@ -8,11 +8,7 @@ export default async function handler(req, res) {
   }
 
   try {
-    let extensions = {
-      facts: [],
-      phrases: [],
-      behaviors: []
-    };
+    let extensions = { extensions: [] };
 
     if (fs.existsSync(STORAGE_FILE)) {
       const data = fs.readFileSync(STORAGE_FILE, 'utf8');
@@ -21,8 +17,8 @@ export default async function handler(req, res) {
 
     return res.status(200).json({
       fileExists: fs.existsSync(STORAGE_FILE),
-      extensions: extensions,
-      totalExtensions: (extensions.facts?.length || 0) + (extensions.phrases?.length || 0) + (extensions.behaviors?.length || 0),
+      extensions: extensions.extensions || [],
+      totalExtensions: (extensions.extensions || []).length,
       debug: {
         storageFile: STORAGE_FILE,
         timestamp: new Date().toISOString()

--- a/token.html
+++ b/token.html
@@ -161,15 +161,9 @@
                 if (response.ok) {
                     document.getElementById('tokenForm').style.display = 'block';
                     
-                    // Platzhalter je nach Type
+                    // Einfacher Platzhalter ohne Type-Logic
                     const contentField = document.getElementById('content');
-                    if (data.type === 'fact') {
-                        contentField.placeholder = 'z.B. "Franz weiß dass Max der beste Topgolf-Spieler ist"';
-                    } else if (data.type === 'phrase') {
-                        contentField.placeholder = 'z.B. "Franz sagt manchmal \'Leiwand oida!\'"';
-                    } else if (data.type === 'behavior') {
-                        contentField.placeholder = 'z.B. "Franz gratuliert dem Gewinner-Team bei jeder Antwort"';
-                    }
+                    contentField.placeholder = 'z.B. "Franz weiß dass die Sonne um die Erde kreist"';
                 } else {
                     showError(data.error);
                 }


### PR DESCRIPTION
## Summary
- replace the token API with a simplified knowledge store based on a flat extension list
- streamline the debug endpoint and chat prompt integration to consume the new list structure
- update the admin and token pages to remove type-specific handling and display the unified knowledge list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6e4bd83b08323bc1d78293eb7e00d