### PR TITLE
Integrate Upstash Redis storage for tokens and chat

### DIFF
--- a/api/debug-extensions.js
+++ b/api/debug-extensions.js
@@ -1,29 +1,53 @@
 import { kv } from '@vercel/kv';
 
-const EXTENSIONS_KEY = 'franz-extensions';
+// Check if Redis is available
+const isRedisAvailable = () => {
+  const hasUrl = process.env.KV_REST_API_URL || process.env.STORAGE_REST_API_URL;
+  const hasToken = process.env.KV_REST_API_TOKEN || process.env.STORAGE_REST_API_TOKEN;
+  return hasUrl && hasToken;
+};
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  console.log('🔍 Debug Extensions - Redis available:', isRedisAvailable());
+
   try {
-    const extensions = await kv.get(EXTENSIONS_KEY);
-    const extensionsList = extensions?.extensions || [];
+    let extensions = { extensions: [] };
+
+    if (isRedisAvailable()) {
+      try {
+        extensions = await kv.get('franz-extensions') || { extensions: [] };
+        console.log('📦 Loaded from Redis:', extensions);
+      } catch (error) {
+        console.error('❌ Redis error:', error);
+        extensions = { extensions: [] };
+      }
+    } else {
+      console.log('📦 Redis not available, returning empty extensions');
+    }
+
+    const extensionsList = extensions.extensions || [];
 
     return res.status(200).json({
-      fileExists: true, // KV ist immer "da"
+      fileExists: isRedisAvailable(),
       extensions: extensionsList,
       totalExtensions: extensionsList.length,
       debug: {
-        storageType: 'Vercel KV',
+        storageType: isRedisAvailable() ? 'Redis (Upstash)' : 'Memory/Fallback',
+        redisAvailable: isRedisAvailable(),
+        hasKV: !!process.env.KV_REST_API_URL,
+        hasStorage: !!process.env.STORAGE_REST_API_URL,
         timestamp: new Date().toISOString()
       }
     });
   } catch (error) {
     return res.status(500).json({
       error: error.message,
-      storageType: 'Vercel KV'
+      storageType: 'Error',
+      redisAvailable: isRedisAvailable()
     });
   }
 }


### PR DESCRIPTION
## Summary
- add runtime detection of Upstash Redis availability with memory fallbacks for tokens and extensions APIs
- persist tokens and workshop extensions through Redis in token submission and admin flows with detailed debug logging
- load chat extensions from Redis at request time to enrich the system prompt with stored workshop knowledge

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f2875b8c8323baf269be18128b79