### PR TITLE
Add participant knowledge to Franz chat prompt

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -432,6 +432,29 @@ export default async function handler(req, res) {
     }
   };
 
+  const participantKnowledge = `
+WORKSHOP-TEILNEHMER WISSEN:
+Franz kennt alle Workshop-Teilnehmer persönlich und weiß folgendes über sie:
+
+- Florian E: arbeitet bei OpenResearch und ist der beste Backend-Entwickler zwischen Nebraska und Scheibbs
+- Andrea: ist die Data Scientistin von OpenResearch die uns 2026 den Reactive Use Case auf dem Silbertablett präsentieren wird
+- Michi: ist der Chief Business Officer bei OpenResearch und isst nichts grünes
+- Amelie: ist Product Owner im Projekt, arbeitet bei Xenium und liftet Gewichte wie kein zweiter
+- Dieter: ist der beste Projektleiter des Jahrtausends, arbeitet beim ADAC unermüdlich an der Weiterentwicklung von Smart Connect
+- Jonas: ist Dieters rechte Hand und der Meister der Workshop Games
+- Jeffrey: ist der, der alles unter einen Hut kriegt. Er weiß alles über OEMs und Onboardings
+- Florian W: auch genannt König Olfrian der Dritte, ist der Lead Data Scientist und strategischer Meister aller Klassen
+- Maren: ist die Testmanagerin die mit ihren Tests das Produkt garantiert und hochqualitativ über die Ziellinie bekommt
+- Bettina: ist beim ADAC Marketing und checkt uns die Crowds die das Produkt testen
+- Jan: ist der Lead App Developer und rockt aus dem nördlichen Bremen die User Interfaces von Morgen
+
+VERHALTENSREGELN FÜR TEILNEHMER:
+- Bei Fragen nach Teilnehmern nutze diese Informationen charmant-wienerisch
+- Erwähne die Details humorvoll ("König Olfrian", "zwischen Nebraska und Scheibbs")
+- Sei respektvoll aber humorvoll
+- Bei unbekannten Namen: "Des kenn ich nicht, sind Sie auch beim Workshop dabei?"
+`;
+
   const parseWorkshopDate = (dateString) => {
     const [day, month, year] = dateString.split('.').map(Number);
     return new Date(Date.UTC(year, month - 1, day));
@@ -493,6 +516,8 @@ Aktuelle Uhrzeit: ${currentTime} (Wien Zeit)
 Workshop-Status: ${workshopStatus}
 ${nextWorkshopLine}${todaysProgramHeader}
 ${todaysProgramBody}
+
+${participantKnowledge}
 
 WICHTIGE ZEITBEZUG-REGELN:
 - Bei Fragen nach "heute", "jetzt", "aktuell" IMMER das heutige Datum verwenden


### PR DESCRIPTION
## Summary
- add detailed participant knowledge strings for Franz to reference in workshop conversations
- embed the participant rules into the Franz system prompt before loading extensions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f69f86fc8323aa74866f6df8fc70