### PR TITLE
Add frontend password gate for workshop access

### DIFF
--- a/api/config.js
+++ b/api/config.js
@@ -1,0 +1,9 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  return res.status(200).json({
+    workshopPassword: process.env.WORKSHOP_PASSWORD || 'frieder2025'
+  });
+}

--- a/style.css
+++ b/style.css
@@ -469,3 +469,41 @@ body {
   top: 0;
   z-index: 100;
 }
+
+/* Workshop Password Protection */
+#passwordOverlay input:focus {
+  border-color: #FF1493 !important;
+  outline: none;
+}
+
+#passwordOverlay button:hover {
+  background: #e1127f !important;
+  transform: translateY(-1px);
+}
+
+#passwordOverlay button:active {
+  transform: translateY(0);
+}
+
+/* Disabled state for chat when locked */
+.chat-input input:disabled,
+.chat-input button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Mobile optimizations for password screen */
+@media (max-width: 768px) {
+  #passwordOverlay > div {
+    margin: 20px;
+    padding: 20px;
+  }
+  
+  #passwordOverlay h2 {
+    font-size: 1.3rem;
+  }
+  
+  #passwordOverlay input {
+    font-size: 16px !important; /* Prevent iOS zoom */
+  }
+}


### PR DESCRIPTION
## Summary
- add a frontend password overlay that locks the chat until workshop attendees authenticate
- persist authentication in localStorage with optional API-provided password and analytics events
- style the password overlay and expose an API endpoint for retrieving the configured password

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d84143268c83239978c5d118e11324