### PR TITLE
Add flash animation for new live activities and remove pulse effects

### DIFF
--- a/alex-brain.html
+++ b/alex-brain.html
@@ -270,7 +270,7 @@
             right: 0;
             height: 2px;
             background: linear-gradient(90deg, #ff6b6b, #4ecdc4, #45b7d1, #f39c12);
-            animation: shimmer 3s infinite;
+            /* animation: shimmer 3s infinite; ENTFERNT */
         }
 
         .teen-conversation-card:hover {
@@ -317,27 +317,23 @@
             width: 6px;
             height: 6px;
             border-radius: 50%;
-            animation: flowPulse 1.5s infinite;
+            animation: flowPulse 2s infinite; /* Langsamere, subtilere Animation */
         }
 
         .processing-flow.super-fast .flow-dots span {
             background: #7ee787;
-            animation-duration: 0.8s;
         }
 
         .processing-flow.fast .flow-dots span {
             background: #58a6ff;
-            animation-duration: 1.2s;
         }
 
         .processing-flow.normal .flow-dots span {
             background: #f2cc60;
-            animation-duration: 1.5s;
         }
 
         .processing-flow.slow .flow-dots span {
             background: #f85149;
-            animation-duration: 2s;
         }
 
         .flow-dots span:nth-child(2) { animation-delay: 0.3s; }
@@ -433,22 +429,22 @@
 
         .message-flow.super-fast .flow-line {
             background: linear-gradient(90deg, #7ee787, #56d364);
-            animation: superFastPulse 0.8s infinite;
+            /* animation: superFastPulse 0.8s infinite; ENTFERNT */
         }
 
         .message-flow.fast .flow-line {
             background: linear-gradient(90deg, #58a6ff, #1f6feb);
-            animation: fastPulse 1.2s infinite;
+            /* animation: fastPulse 1.2s infinite; ENTFERNT */
         }
 
         .message-flow.normal .flow-line {
             background: linear-gradient(90deg, #f2cc60, #d29922);
-            animation: normalPulse 1.5s infinite;
+            /* animation: normalPulse 1.5s infinite; ENTFERNT */
         }
 
         .message-flow.slow .flow-line {
             background: linear-gradient(90deg, #f85149, #da3633);
-            animation: slowPulse 2s infinite;
+            /* animation: slowPulse 2s infinite; ENTFERNT */
         }
 
         .flow-arrow {
@@ -477,7 +473,8 @@
             background: #fff;
             border-radius: 50%;
             transform: translate(-50%, -50%);
-            animation: sparkle 2s infinite;
+            /* animation: sparkle 2s infinite; ENTFERNT */
+            opacity: 0.6; /* Statische opacity statt animation */
         }
 
         /* ===== PERFORMANCE FOOTER ===== */
@@ -553,7 +550,7 @@
             border-radius: 16px;
             padding: 16px;
             margin-bottom: 16px;
-            animation: thinkingPulse 2s infinite;
+            /* animation: thinkingPulse 2s infinite; ENTFERNT */
             backdrop-filter: blur(8px);
         }
 
@@ -676,55 +673,72 @@
             font-size: 0.85rem;
         }
 
+        /* ===== FLASH ANIMATION FÜR NEUE AKTIVITÄTEN ===== */
+        .activity-flash-container {
+            position: relative;
+            transition: all 0.3s ease;
+        }
+
+        .activity-flash-container.flash-in {
+            animation: activityFlash 2s ease-out;
+        }
+
+        @keyframes activityFlash {
+            0% {
+                background: linear-gradient(135deg, rgba(88, 166, 255, 0.3), rgba(126, 231, 135, 0.3));
+                box-shadow: 0 0 0 0 rgba(88, 166, 255, 0.8);
+                transform: scale(1.02);
+            }
+            10% {
+                background: linear-gradient(135deg, rgba(88, 166, 255, 0.2), rgba(126, 231, 135, 0.2));
+                box-shadow: 0 0 0 8px rgba(88, 166, 255, 0.4);
+                transform: scale(1.01);
+            }
+            20% {
+                background: linear-gradient(135deg, rgba(88, 166, 255, 0.1), rgba(126, 231, 135, 0.1));
+                box-shadow: 0 0 0 16px rgba(88, 166, 255, 0.2);
+                transform: scale(1);
+            }
+            40% {
+                background: linear-gradient(135deg, rgba(88, 166, 255, 0.05), rgba(126, 231, 135, 0.05));
+                box-shadow: 0 0 0 24px rgba(88, 166, 255, 0.1);
+            }
+            100% {
+                background: transparent;
+                box-shadow: 0 0 0 32px rgba(88, 166, 255, 0);
+            }
+        }
+
+        .activity-flash-container[data-new="true"] .teen-conversation-card {
+            border-color: rgba(88, 166, 255, 0.6);
+        }
+
+        .activity-flash-container[data-new="true"] .thinking-card-teen {
+            border-color: rgba(248, 81, 73, 0.8);
+        }
+
+        .activity-flash-container[data-new="true"] .token-card-teen {
+            border-color: rgba(210, 153, 34, 0.8);
+        }
+
+        .activity-flash-container[data-new="true"] .error-card-teen {
+            border-color: rgba(218, 54, 51, 0.8);
+        }
+
         /* ===== ANIMATIONS ===== */
         @keyframes bounce {
             0%, 80%, 100% { transform: translateY(0); }
-            40% { transform: translateY(-12px); }
+            40% { transform: translateY(-8px); } /* Kleinerer bounce */
         }
 
         @keyframes flowPulse {
             0%, 100% { opacity: 0.4; }
-            50% { opacity: 1; }
-        }
-
-        @keyframes shimmer {
-            0% { transform: translateX(-100%); }
-            100% { transform: translateX(100%); }
-        }
-
-        @keyframes superFastPulse {
-            0%, 100% { opacity: 0.6; }
-            50% { opacity: 1; transform: scale(1.1); }
-        }
-
-        @keyframes fastPulse {
-            0%, 100% { opacity: 0.7; }
-            50% { opacity: 1; transform: scale(1.05); }
-        }
-
-        @keyframes normalPulse {
-            0%, 100% { opacity: 0.8; }
-            50% { opacity: 1; }
-        }
-
-        @keyframes slowPulse {
-            0%, 100% { opacity: 0.9; }
-            50% { opacity: 1; transform: scale(0.95); }
-        }
-
-        @keyframes sparkle {
-            0%, 100% { opacity: 0; transform: translate(-50%, -50%) scale(0); }
-            50% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
-        }
-
-        @keyframes thinkingPulse {
-            0%, 100% { box-shadow: 0 0 0 0 rgba(248, 81, 73, 0.4); }
-            50% { box-shadow: 0 0 0 12px rgba(248, 81, 73, 0); }
+            50% { opacity: 0.8; } /* Weniger intensiv */
         }
 
         @keyframes bigBounce {
             0%, 80%, 100% { transform: translateY(0); }
-            40% { transform: translateY(-10px); }
+            40% { transform: translateY(-6px); } /* Kleinerer bounce */
         }
 
         /* ===== RESPONSIVE ===== */
@@ -918,6 +932,7 @@
         let autoRefreshInterval = null;
         let isAutoRefresh = false;
         let eventSource = null;
+        let lastActivityIds = new Set();
 
         async function loadBrainState() {
             const loadingEl = document.getElementById('loadingState');
@@ -1005,6 +1020,18 @@
                     try {
                         const data = JSON.parse(event.data);
                         updateActivityDisplay(data);
+
+                        if (data.recentActivities && data.recentActivities.length > 0) {
+                            const latestActivity = data.recentActivities[0];
+
+                            if (latestActivity.type === 'token_used') {
+                                console.log('🎫 TOKEN FLASH!');
+                            } else if (latestActivity.type === 'request_start') {
+                                console.log('📥 NEW QUESTION FLASH!');
+                            } else if (latestActivity.type === 'request_end') {
+                                console.log('📤 NEW ANSWER FLASH!');
+                            }
+                        }
                     } catch (error) {
                         console.error('Activity parse error:', error);
                     }
@@ -1081,28 +1108,81 @@
                         </div>
                     </div>
                 `;
+                lastActivityIds.clear();
                 return;
             }
 
-            // Gruppiere Request/Response Paare
             const groupedActivities = groupRequestResponse(activities);
 
-            console.log('🎨 RENDERING:', groupedActivities.length, 'items');
+            const currentActivityIds = new Set();
+            const newActivityIds = new Set();
+
+            groupedActivities.forEach(group => {
+                const groupId = group.id || group.activity?.id || `generated_${group.type || 'activity'}_${group.timestamp}`;
+                currentActivityIds.add(groupId);
+
+                if (!lastActivityIds.has(groupId)) {
+                    newActivityIds.add(groupId);
+                }
+            });
+
+            console.log('🎨 RENDERING:', {
+                total: groupedActivities.length,
+                new: newActivityIds.size,
+                newIds: Array.from(newActivityIds)
+            });
 
             feed.innerHTML = groupedActivities.map(group => {
+                const groupId = group.id || group.activity?.id || `generated_${group.type || 'activity'}_${group.timestamp}`;
+                const isNew = newActivityIds.has(groupId);
+
+                let html = '';
                 switch(group.type) {
                     case 'conversation':
-                        return renderTeenConversation(group);
+                        html = renderTeenConversation(group);
+                        break;
                     case 'active_thinking':
-                        return renderActiveThinking(group);
+                        html = renderActiveThinking(group);
+                        break;
                     case 'error':
-                        return renderError(group);
+                        html = renderError(group);
+                        break;
                     case 'token_redeemed':
-                        return renderTokenRedeemed(group);
+                        html = renderTokenRedeemed(group);
+                        break;
                     default:
                         return '';
                 }
+
+                if (isNew && html) {
+                    html = `<div class="activity-flash-container" data-new="true">${html}</div>`;
+                }
+
+                return html;
             }).join('');
+
+            lastActivityIds = new Set(currentActivityIds);
+
+            if (newActivityIds.size > 0) {
+                triggerFlashAnimations();
+            }
+        }
+
+        function triggerFlashAnimations() {
+            setTimeout(() => {
+                const newItems = document.querySelectorAll('.activity-flash-container[data-new="true"]');
+
+                newItems.forEach((item, index) => {
+                    setTimeout(() => {
+                        item.classList.add('flash-in');
+
+                        setTimeout(() => {
+                            item.classList.remove('flash-in');
+                            item.removeAttribute('data-new');
+                        }, 2000);
+                    }, index * 100);
+                });
+            }, 50);
         }
 
         function groupRequestResponse(activities) {


### PR DESCRIPTION
## Summary
- highlight newly streamed activity feed entries with a temporary flash container
- tone down existing feed visuals by removing shimmer and pulse animations while keeping subtle dot movement
- add logging hooks to live activity updates for better flash diagnostics

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8ab942208323acc5c7e3604fc833